### PR TITLE
datatrove v0.9.0 (fixes bot PR #8)

### DIFF
--- a/recipe/cli.patch
+++ b/recipe/cli.patch
@@ -1,9 +1,10 @@
 diff --git a/src/datatrove/tools/check_dataset.py b/src/datatrove/tools/check_dataset.py
-index 763e5c3..507dc6f 100644
 --- a/src/datatrove/tools/check_dataset.py
 +++ b/src/datatrove/tools/check_dataset.py
-@@ -94,10 +94,13 @@ def check_dataset(input_folder: DataFolder, tokenizer: str = "gpt2", eos_token:
-             assert last_token == eos_token, f"no EOS at doc end of doc {doci}"
+@@ -95,10 +95,13 @@ def check_dataset(
+             assert last_token == eos_token or (chunk_size and read_count % chunk_size == 0), (
+                 f"no EOS at doc end of doc {doci}"
+             )
  
  
 -if __name__ == "__main__":
@@ -18,10 +19,9 @@ index 763e5c3..507dc6f 100644
 +if __name__ == "__main__":
 +    main()
 diff --git a/src/datatrove/tools/inspect_data.py b/src/datatrove/tools/inspect_data.py
-index 4dce04b..e062589 100644
 --- a/src/datatrove/tools/inspect_data.py
 +++ b/src/datatrove/tools/inspect_data.py
-@@ -40,7 +40,7 @@ parser.add_argument(
+@@ -40,7 +40,7 @@
  )
  
  parser.add_argument(

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   name: datatrove
-  version: "0.8.0"
+  version: "0.9.0"
   python_min: "3.10"
 
 package:
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/datatrove-${{ version }}.tar.gz
-  sha256: 7aff3ed59bce1a88173eebe3171c47918e25ae969d6fa7259edf8749e13efff3
+  sha256: 2c4ae41ed3e1f81fdd09e035ff7591d031ad1abbdbcb74eecbf6ab18c86b9c77
   patches:
     # Upstream issue: https://github.com/huggingface/datatrove/issues/315
     - cli.patch
@@ -36,7 +36,7 @@ requirements:
     - python >=${{ python_min }}
     - dill >=0.3.0
     - fsspec >=2023.12.2
-    - huggingface_hub >=0.17.0
+    - huggingface_hub >=0.34.0,<1.0
     - humanize
     - loguru >=0.7.0
     - multiprocess


### PR DESCRIPTION
Bump datatrove to v0.9.0 with fixes for the failing bot PR #8.

**Changes from the bot PR (#8):**
- Version bump from 0.8.0 to 0.9.0 with updated sha256

**Additional fixes:**
- **Updated `cli.patch`** — The `check_dataset.py` context lines changed in v0.9.0 (added `chunk_size` parameter to the assert). The old patch from v0.8.0 failed to apply, causing the Azure build failure.
- **Updated `huggingface_hub` constraint** — Upstream changed from `>=0.17.0` to `>=0.34.0,<1.0` in v0.9.0.

Supersedes #8.